### PR TITLE
Only write to Kv when status changed

### DIFF
--- a/src/util/api/nvidia/NvidiaApi.ts
+++ b/src/util/api/nvidia/NvidiaApi.ts
@@ -49,7 +49,9 @@ export class NvidiaApi {
           await sendToNtfy(product, store, productApi, env, true);
         }
 
-        await saveStockStatus(env, sku, isInStock ? 'in_stock' : 'out_of_stock');
+        if (previousStatus !== (isInStock ? 'in_stock' : 'out_of_stock')) {
+          await saveStockStatus(env, sku, isInStock ? 'in_stock' : 'out_of_stock');
+        }
       }
 
       results.push(...purchasableProducts);


### PR DESCRIPTION
Fixes #10

Add a condition to check if the status has changed before writing to Kv.

* Modify `fetchInventory` method in `src/util/api/nvidia/NvidiaApi.ts` to include a condition that compares the current status with the previous status before calling `saveStockStatus`.
* Only call `saveStockStatus` if the status has changed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/nvidia-fe-cloudflare-worker/pull/11?shareId=33a2c85f-0c78-4798-9962-06c1f3277c96).