### PR TITLE
Update Coolblue notification to use product name

### DIFF
--- a/src/util/api/coolblue/CoolblueApi.ts
+++ b/src/util/api/coolblue/CoolblueApi.ts
@@ -1,5 +1,6 @@
 import { sendCoolblueNotification } from '../../ntfy/NTFYConnection';
 import { saveStockStatus, getStockStatus } from '../../kv/KVHelper';
+import { COOLBLUE_PRODUCTS } from '../../const';
 
 export class CoolblueApi {
   public async fetchInventory(productUrl: string, env: Env): Promise<void> {
@@ -8,7 +9,9 @@ export class CoolblueApi {
 
     const previousStatus = await getStockStatus(env, productUrl);
     if (stockStatus !== previousStatus) {
-      await sendCoolblueNotification(productUrl, stockStatus, env);
+      const product = COOLBLUE_PRODUCTS.find(p => p.url === productUrl);
+      const productName = product ? product.name : 'Unknown Product';
+      await sendCoolblueNotification(productUrl, productName, stockStatus, env);
       await saveStockStatus(env, productUrl, stockStatus);
     }
   }

--- a/src/util/ntfy/NTFYConnection.ts
+++ b/src/util/ntfy/NTFYConnection.ts
@@ -44,13 +44,13 @@ export async function sendToNtfy(
   await postToNtfy(env.NTFY_URL, bodyObject, headers);
 }
 
-export async function sendCoolblueNotification(productUrl: string, stockStatus: string, env: Env): Promise<void> {
-  console.log('Sending notification to NTFY for Coolblue product:', productUrl);
+export async function sendCoolblueNotification(productUrl: string, productName: string, stockStatus: string, env: Env): Promise<void> {
+  console.log('Sending notification to NTFY for Coolblue product:', productName);
   const notificationMessage = getCoolblueTemplateString(stockStatus);
   const bodyObject = {
     topic: env.NTFY_TOPIC,
     message: renderTemplateString(notificationMessage.MESSAGE, {
-      PRODUCT_URL: productUrl,
+      PRODUCT_NAME: productName,
       STOCK_STATUS: stockStatus,
     }),
     actions: [
@@ -64,7 +64,7 @@ export async function sendCoolblueNotification(productUrl: string, stockStatus: 
 
   const headers = {
     Title: renderTemplateString(notificationMessage.MESSAGE, {
-      PRODUCT_URL: productUrl,
+      PRODUCT_NAME: productName,
       STOCK_STATUS: stockStatus,
     }),
     Priority: notificationMessage.PRIORITY.name,
@@ -102,11 +102,11 @@ function getTemplateString(product: ListMap, firstTimeSeen: boolean): { MESSAGE:
 
 function getCoolblueTemplateString(stockStatus: string): { MESSAGE: string; PRIORITY: { name: string; rank: number } } {
   if (stockStatus === 'on_stock') {
-    return { MESSAGE: 'Coolblue product is now in stock {{PRODUCT_URL}}', PRIORITY: { name: 'high', rank: 1 } };
+    return { MESSAGE: 'Coolblue product is now in stock {{PRODUCT_NAME}}', PRIORITY: { name: 'high', rank: 1 } };
   } else if (stockStatus === 'available_soon') {
-    return { MESSAGE: 'Coolblue product will be available soon {{PRODUCT_URL}}', PRIORITY: { name: 'medium', rank: 2 } };
+    return { MESSAGE: 'Coolblue product will be available soon {{PRODUCT_NAME}}', PRIORITY: { name: 'medium', rank: 2 } };
   }
-  return { MESSAGE: 'Coolblue product is out of stock {{PRODUCT_URL}}', PRIORITY: { name: 'low', rank: 3 } };
+  return { MESSAGE: 'Coolblue product is out of stock {{PRODUCT_NAME}}', PRIORITY: { name: 'low', rank: 3 } };
 }
 
 function getPriorityForProductNotification(


### PR DESCRIPTION
Modify the `sendCoolblueNotification` function to use the product name instead of the URL in the `bodyObject` and `headers`.

* **CoolblueApi.ts**
  - Import `COOLBLUE_PRODUCTS` constant.
  - Modify `fetchInventory` function to find the product name based on the product URL and pass it to `sendCoolblueNotification`.

* **NTFYConnection.ts**
  - Modify `sendCoolblueNotification` function to accept `productName` as a parameter.
  - Update the `bodyObject` and `headers` to use `productName` instead of `productUrl`.
  - Update `getCoolblueTemplateString` function to use `productName` in the notification message templates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/nvidia-fe-cloudflare-worker/pull/14?shareId=245f72e6-1f82-4aa1-89e3-d29f29009f0a).