### PR TITLE
Add bol.com API for NVIDIA GeForce RTX 5090 series

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { NvidiaApi } from './util/api/nvidia/NvidiaApi';
 import { CoolblueApi } from './util/api/coolblue/CoolblueApi';
-import { NVIDIA_STORES, COOLBLUE_PRODUCTS } from './util/const';
+import { BolApi } from './util/api/bol/BolApi';
+import { NVIDIA_STORES, COOLBLUE_PRODUCTS, BOL_PRODUCTS } from './util/const';
 
 const app = new Hono();
 
@@ -14,6 +15,10 @@ const app = new Hono();
   for (const product of COOLBLUE_PRODUCTS) {
     const coolblueApi = new CoolblueApi();
     await coolblueApi.fetchInventory(product.url, env);
+  }
+  for (const product of BOL_PRODUCTS) {
+    const bolApi = new BolApi();
+    await bolApi.fetchInventory(product.url, env);
   }
 };
 
@@ -36,6 +41,11 @@ app.get('/api/test', async c => {
     const coolblueApi = new CoolblueApi();
     await coolblueApi.fetchInventory(product.url, c.env as Env);
   }
+  for (const product of BOL_PRODUCTS) {
+    console.log('Processing product in /api/test route:', product);
+    const bolApi = new BolApi();
+    await bolApi.fetchInventory(product.url, c.env as Env);
+  }
   return c.json({ message: 'Hello World!' });
 });
 
@@ -54,6 +64,15 @@ app.get('/api/coolblue', async c => {
     await coolblueApi.fetchInventory(product.url, c.env as Env);
   }
   return c.json({ message: 'Coolblue products processed!' });
+});
+
+app.get('/api/bol', async c => {
+  for (const product of BOL_PRODUCTS) {
+    console.log('Processing product in /api/bol route:', product);
+    const bolApi = new BolApi();
+    await bolApi.fetchInventory(product.url, c.env as Env);
+  }
+  return c.json({ message: 'Bol.com products processed!' });
 });
 
 export default app;

--- a/src/util/api/bol/BolApi.ts
+++ b/src/util/api/bol/BolApi.ts
@@ -1,0 +1,57 @@
+import { sendCoolblueNotification } from '../../ntfy/NTFYConnection';
+import { saveStockStatus, getStockStatus } from '../../kv/KVHelper';
+import { BOL_PRODUCTS } from '../../const';
+
+export class BolApi {
+  public async fetchInventory(productUrl: string, env: Env): Promise<void> {
+    const html = await this.fetchHtmlContent(productUrl);
+    const stockStatus = this.extractStockStatusFromHtml(html);
+
+    const previousStatus = await getStockStatus(env, productUrl);
+    if (stockStatus !== previousStatus) {
+      const product = BOL_PRODUCTS.find(p => p.url === productUrl);
+      const productName = product ? product.name : 'Unknown Product';
+      await sendCoolblueNotification(productUrl, productName, stockStatus, env);
+      await saveStockStatus(env, productUrl, stockStatus);
+    }
+  }
+
+  private async fetchHtmlContent(url: string): Promise<string> {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'nl,en-US;q=0.7,en;q=0.3',
+        'Accept-Encoding': 'gzip, deflate, br, zstd',
+        Connection: 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+        'Sec-Fetch-Dest': 'document',
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'cross-site',
+        'Sec-GPC': '1',
+        Priority: 'u=0, i',
+        TE: 'trailers',
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch HTML content from ${url}`);
+    }
+    return response.text();
+  }
+
+  private extractStockStatusFromHtml(html: string): string {
+    const ldJsonSplit = html.split('<script type="application/ld+json">');
+    if (ldJsonSplit.length < 2) {
+      return 'stock_status not found';
+    }
+
+    const ldJson = ldJsonSplit[1].split('</script>')[0];
+    const productData = JSON.parse(ldJson);
+
+    if (productData.hasVariant && Array.isArray(productData.hasVariant) && productData.hasVariant.length > 0) {
+      return productData.hasVariant[0].offers.availability || 'stock_status not found';
+    }
+
+    return productData.offers.availability || 'stock_status not found';
+  }
+}

--- a/src/util/api/bol/BolApi.ts
+++ b/src/util/api/bol/BolApi.ts
@@ -1,4 +1,4 @@
-import { sendCoolblueNotification } from '../../ntfy/NTFYConnection';
+import { sendBolNotification } from '../../ntfy/NTFYConnection';
 import { saveStockStatus, getStockStatus } from '../../kv/KVHelper';
 import { BOL_PRODUCTS } from '../../const';
 
@@ -11,7 +11,7 @@ export class BolApi {
     if (stockStatus !== previousStatus) {
       const product = BOL_PRODUCTS.find(p => p.url === productUrl);
       const productName = product ? product.name : 'Unknown Product';
-      await sendCoolblueNotification(productUrl, productName, stockStatus, env);
+      await sendBolNotification(productUrl, productName, stockStatus, env);
       await saveStockStatus(env, productUrl, stockStatus);
     }
   }

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -41,6 +41,29 @@ export const COOLBLUE_PRODUCTS = [
   },
 ];
 
+export const BOL_PRODUCTS = [
+  {
+    url: 'https://www.bol.com/nl/nl/p/msi-nvidia-geforce-rtx-5090-32g-gaming-trio-oc-videokaart-32gb-gddr7-pcie-5-0-1x-hdmi-2-1b-3x-displayport-2-1a/9300000222902218/?bltgh=fa83d7e9-c9aa-4105-b101-43cc316c0b14.wishlist_details_page_products.WishlistDetailProductCardItem_4.ProductTitle',
+    name: 'MSI - NVIDIA GeForce RTX 5090 32G GAMING TRIO OC - Videokaart - 32GB - GDDR7 - PCIe 5.0 - 1x HDMI 2.1b - 3x DisplayPort 2.1a',
+  },
+  {
+    url: 'https://www.bol.com/nl/nl/p/msi-nvidia-geforce-rtx-5090-32g-suprim-liquid-soc-videokaart-32gb-gddr7-pcie-5-0-1x-hdmi-2-1b-3x-displayport-2-1a/9300000222902221/?bltgh=fa83d7e9-c9aa-4105-b101-43cc316c0b14.wishlist_details_page_products.WishlistDetailProductCardItem_3.ProductTitle',
+    name: 'MSI - NVIDIA GeForce RTX 5090 32G SUPRIM LIQUID SOC - Videokaart - 32GB - GDDR7 - PCIe 5.0 - 1x HDMI 2.1b - 3x DisplayPort 2.1a',
+  },
+  {
+    url: 'https://www.bol.com/nl/nl/p/msi-ventus-geforce-rtx-5090-32g-3x-oc-videokaart-nvidia-32-gb-gddr7/9300000222902226/?bltgh=fa83d7e9-c9aa-4105-b101-43cc316c0b14.wishlist_details_page_products.WishlistDetailProductCardItem_2.ProductTitle',
+    name: 'MSI VENTUS GEFORCE RTX 5090 32G 3X OC videokaart NVIDIA 32 GB GDDR7',
+  },
+  {
+    url: 'https://www.bol.com/nl/nl/p/gigabyte-geforce-rtx-5090-windforce-oc-32g-nvidia-32-gb-gddr7/9300000224382653/?bltgh=fa83d7e9-c9aa-4105-b101-43cc316c0b14.wishlist_details_page_products.WishlistDetailProductCardItem_1.ProductTitle',
+    name: 'GIGABYTE GeForce RTX 5090 WINDFORCE OC 32G NVIDIA 32 GB GDDR7',
+  },
+  {
+    url: 'https://www.bol.com/nl/nl/p/pny-geforce-rtx-5090-oc-nvidia-32-gb-gddr7/9300000224383133/?bltgh=fa83d7e9-c9aa-4105-b101-43cc316c0b14.wishlist_details_page_products.WishlistDetailProductCardItem_0.ProductTitle',
+    name: 'PNY GeForce RTX 5090 OC NVIDIA 32 GB GDDR7',
+  },
+];
+
 export const GPU_SERIES = {
   '5080': '5080',
   '5090': '5090',


### PR DESCRIPTION
Fixes #25

Add bol.com links and API for NVIDIA GeForce RTX 5090 series.

* **Add BolApi class**: Create `BolApi` class in `src/util/api/bol/BolApi.ts` to handle bol.com API requests, including methods to fetch HTML content and extract stock status.
* **Update constants**: Modify `src/util/const.ts` to include bol.com product URLs and names for NVIDIA GeForce RTX 5090 series.
* **Update index.ts**: Import `BolApi` class and add bol.com products to the scheduled function and relevant API routes in `src/index.ts`.
* **Add bol.com specific variables**: Update `worker-configuration.d.ts` and `.dev.vars.example` to include bol.com specific variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/nvidia-fe-cloudflare-worker/pull/26?shareId=caeb26dc-5c24-46ea-8774-21e6c7c5e237).