### PR TITLE
Add alternate links for ZOTAC and ASUS GeForce RTX 5090 graphics cards

### DIFF
--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -77,6 +77,30 @@ export const ALTERNATE_STORE = [
     url: 'https://www.alternate.de/GIGABYTE/GeForce-RTX-5090-AORUS-MASTER-32G-Grafikkarte/html/product/100108932',
     name: 'GIGABYTE GeForce RTX 5090 AORUS MASTER 32G',
   },
+  {
+    url: 'https://www.alternate.de/ZOTAC/GeForce-RTX-5090-SOLID-Grafikkarte/html/product/100110077',
+    name: 'ZOTAC GeForce RTX 5090 SOLID',
+  },
+  {
+    url: 'https://www.alternate.de/ZOTAC/GeForce-RTX-5090-SOLID-OC-Grafikkarte/html/product/100110079',
+    name: 'ZOTAC GeForce RTX 5090 SOLID OC',
+  },
+  {
+    url: 'https://www.alternate.de/GIGABYTE/GeForce-RTX-5090-WINDFORCE-OC-32G-Grafikkarte/html/product/100108938',
+    name: 'GIGABYTE GeForce RTX 5090 WINDFORCE OC 32G',
+  },
+  {
+    url: 'https://www.alternate.de/ZOTAC/GeForce-RTX-5090-AMP-Extreme-INFINITY-Grafikkarte/html/product/100110080',
+    name: 'GeForce RTX 5090 AMP Extreme INFINITY',
+  },
+  {
+    url: 'https://www.alternate.de/ASUS/GeForce-RTX-5090-TUF-GAMING-Grafikkarte/html/product/100110148',
+    name: 'ASUS GeForce RTX 5090 TUF GAMING',
+  },
+  {
+    url: 'https://www.alternate.de/ASUS/GeForce-RTX-5090-TUF-GAMING-OC-Grafikkarte/html/product/100110147',
+    name: 'ASUS GeForce RTX 5090 TUF GAMING OC',
+  },
 ];
 
 export const GPU_SERIES = {


### PR DESCRIPTION
Add alternate links for specified ZOTAC and ASUS GeForce RTX 5090 graphics cards.

* Add ZOTAC GeForce RTX 5090 SOLID link to `ALTERNATE_STORE` array in `src/util/const.ts`
* Add ZOTAC GeForce RTX 5090 SOLID OC link to `ALTERNATE_STORE` array in `src/util/const.ts`
* Add GIGABYTE GeForce RTX 5090 WINDFORCE OC 32G link to `ALTERNATE_STORE` array in `src/util/const.ts`
* Add ZOTAC GeForce RTX 5090 AMP Extreme INFINITY link to `ALTERNATE_STORE` array in `src/util/const.ts`
* Add ASUS GeForce RTX 5090 TUF GAMING link to `ALTERNATE_STORE` array in `src/util/const.ts`
* Add ASUS GeForce RTX 5090 TUF GAMING OC link to `ALTERNATE_STORE` array in `src/util/const.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/nvidia-fe-cloudflare-worker/pull/37?shareId=ea0d1499-0cd9-423a-97dc-fb784d5e2f9a).