### PR TITLE
Modify APIs to only send notification when in stock

### DIFF
--- a/src/util/api/alternate/AlternateApi.ts
+++ b/src/util/api/alternate/AlternateApi.ts
@@ -15,7 +15,7 @@ export class AlternateApi {
     const { price, image, availability } = productData;
     const previousStatus = await getStockStatus(env, productUrl);
 
-    if (availability !== previousStatus) {
+    if (availability === 'InStock' && availability !== previousStatus) {
       const product = ALTERNATE_STORE.find(p => p.url === productUrl);
       const productName = product ? product.name : 'Unknown Product';
       await sendAlternateNotification(productUrl, productName, availability, env, image);

--- a/src/util/api/bol/BolApi.ts
+++ b/src/util/api/bol/BolApi.ts
@@ -8,7 +8,7 @@ export class BolApi {
     const stockStatus = this.extractStockStatusFromHtml(html);
 
     const previousStatus = await getStockStatus(env, productUrl);
-    if (stockStatus !== previousStatus) {
+    if (stockStatus === 'InStock' && stockStatus !== previousStatus) {
       const product = BOL_PRODUCTS.find(p => p.url === productUrl);
       const productName = product ? product.name : 'Unknown Product';
       await sendBolNotification(productUrl, productName, stockStatus, env);

--- a/src/util/api/coolblue/CoolblueApi.ts
+++ b/src/util/api/coolblue/CoolblueApi.ts
@@ -8,7 +8,7 @@ export class CoolblueApi {
     const stockStatus = this.extractStockStatusFromHtml(html);
 
     const previousStatus = await getStockStatus(env, productUrl);
-    if (stockStatus !== previousStatus) {
+    if (stockStatus === 'in_stock' && stockStatus !== previousStatus) {
       const product = COOLBLUE_PRODUCTS.find(p => p.url === productUrl);
       const productName = product ? product.name : 'Unknown Product';
       await sendCoolblueNotification(productUrl, productName, stockStatus, env);

--- a/src/util/api/coolblue/CoolblueApi.ts
+++ b/src/util/api/coolblue/CoolblueApi.ts
@@ -8,7 +8,7 @@ export class CoolblueApi {
     const stockStatus = this.extractStockStatusFromHtml(html);
 
     const previousStatus = await getStockStatus(env, productUrl);
-    if (stockStatus === 'in_stock' && stockStatus !== previousStatus) {
+    if (stockStatus === 'on_stock' && stockStatus !== previousStatus) {
       const product = COOLBLUE_PRODUCTS.find(p => p.url === productUrl);
       const productName = product ? product.name : 'Unknown Product';
       await sendCoolblueNotification(productUrl, productName, stockStatus, env);


### PR DESCRIPTION
Modify APIs to send notifications only when the product is in stock.

* **CoolblueApi.ts**
  - Modify `fetchInventory` method to send notifications only when the product is in stock.
  - Remove the call to `sendCoolblueNotification` when the product is out of stock.

* **BolApi.ts**
  - Modify `fetchInventory` method to send notifications only when the product is in stock.
  - Remove the call to `sendBolNotification` when the product is out of stock.

* **AlternateApi.ts**
  - Modify `fetchInventory` method to send notifications only when the product is in stock.
  - Remove the call to `sendAlternateNotification` when the product is out of stock.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/nvidia-fe-cloudflare-worker/pull/40?shareId=a55362ff-7ce5-48a8-b2ff-fe12f36bd38d).