### PR TITLE
Add Bol product

### DIFF
--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -74,6 +74,10 @@ export const BOL_PRODUCTS = [
     url: 'https://www.bol.com/nl/nl/p/geforce-rtx-5090-32g-suprim-soc/9300000222902224/?bltgh=hcwkFIRBhrt6cTzWHzRCHA.rXFS2igOoZh0hoM7YQFA3w_0_16.19.ProductImage',
     name: 'MSI GeForce RTX 5090 Suprim SOC',
   },
+  {
+    url: 'https://www.bol.com/nl/nl/p/gigabyte-geforce-rtx-5090-windforce-oc-32g-nvidia-32-gb-gddr7/9300000224382652',
+    name: 'GIGABYTE GeForce RTX 5090 WINDFORCE OC',
+  },
 ];
 
 export const ALTERNATE_STORE = [


### PR DESCRIPTION
Fixes #58

Add the Gigabyte GeForce RTX 5090 Windforce OC 32G NVIDIA 32 GB GDDR7 product to the BOL_PRODUCTS array.

* Add the product URL `https://www.bol.com/nl/nl/p/gigabyte-geforce-rtx-5090-windforce-oc-32g-nvidia-32-gb-gddr7/9300000224382652` to the `BOL_PRODUCTS` array in `src/util/const.ts`
* Add the product name `GIGABYTE GeForce RTX 5090 WINDFORCE OC` to the `BOL_PRODUCTS` array in `src/util/const.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/nvidia-fe-cloudflare-worker/pull/59?shareId=bab7c6b1-b198-40e0-96d2-ed4318c344e1).